### PR TITLE
feat: add YARD documentation generation and insert

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        ruby: ['3.2.3']
+        ruby: ['3.1', '3.2']
 
     runs-on: ${{ matrix.os }}
     name: Ruby ${{ matrix.ruby }} on ${{ matrix.os }}

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.1.0
 
 Style/StringLiterals:
   Enabled: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Renamed main file from `lib/ta_lib.rb` to `lib/ta_lib_ffi.rb`
 - Updated require statements in specs and gemspec
 
-## [0.1.0] - 2024-01-21
+## [0.1.0] - 2025-01-21
 
 ### Added
 - Initial release of ta_lib_ffi

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,6 +63,8 @@ GEM
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
+    webrick (1.9.1)
+    yard (0.9.37)
 
 PLATFORMS
   ruby
@@ -74,6 +76,8 @@ DEPENDENCIES
   rubocop-rspec (~> 3.3)
   ruby-lsp-rspec (~> 0.1.20)
   ta_lib_ffi!
+  webrick (~> 1.9)
+  yard (~> 0.9)
 
 BUNDLED WITH
    2.5.6

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # TALibFFI
 
 ![Tests](https://github.com/TA-Lib/ta-lib-ruby/actions/workflows/main.yml/badge.svg)
+![Gem Version](https://img.shields.io/gem/v/ta_lib_ffi.svg)
 
 ## Introduction
 
@@ -8,7 +9,7 @@ TALibFFI is a Ruby binding for [TA-Lib](https://ta-lib.org/) (Technical Analysis
 
 ## Requirements
 
-- Ruby >= 3.0.0
+- Ruby >= 3.1.0
 - TA-Lib >= 0.6.4
 
 ## Installation

--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,7 @@
 
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
+require "yard"
 
 RSpec::Core::RakeTask.new(:spec)
 
@@ -10,3 +11,14 @@ require "rubocop/rake_task"
 RuboCop::RakeTask.new
 
 task default: %i[spec rubocop]
+
+YARD::Rake::YardocTask.new do |t|
+  require_relative "lib/ta_lib_ffi"
+  require_relative "lib/ta_lib_ffi/doc"
+  TALibFFI::Doc.insert
+
+  t.files = ["lib/**/*.rb"]
+  t.options = ["--exclude", "lib/ta_lib_ffi/doc.rb"]
+  t.stats_options = ["--list-undoc"]
+  t.after = -> { TALibFFI::Doc.remove }
+end

--- a/lib/ta_lib_ffi/doc.rb
+++ b/lib/ta_lib_ffi/doc.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+module TALibFFI
+  # Generates documentation for a TA-Lib function
+  #
+  # This module provides methods to generate documentation for TA-Lib functions.
+  # It includes methods to collect input, optional input, and output information,
+  # and to generate documentation for each function.
+  module Doc
+    module_function
+
+    def insert
+      puts "Inserting documentation"
+      file_path = File.expand_path("../ta_lib_ffi.rb", __dir__)
+      content = File.read(file_path)
+
+      new_content = content.sub(
+        /### GENERATED DOCUMENTATION START ###.*### GENERATED DOCUMENTATION END ###/m,
+        "### GENERATED DOCUMENTATION START ###\n#{generate}\n    ### GENERATED DOCUMENTATION END ###"
+      )
+
+      File.write(file_path, new_content)
+    end
+
+    def remove
+      puts "Removing documentation"
+      file_path = File.expand_path("../ta_lib_ffi.rb", __dir__)
+      content = File.read(file_path)
+
+      new_content = content.sub(
+        /### GENERATED DOCUMENTATION START ###.*### GENERATED DOCUMENTATION END ###/m,
+        "### GENERATED DOCUMENTATION START ###\n    ### GENERATED DOCUMENTATION END ###"
+      )
+
+      File.write(file_path, new_content)
+    end
+
+    def generate
+      docs = []
+      TALibFFI.function_info_map.each_value do |h|
+        docs << generate_function_documentation(h[:info], h[:inputs], h[:opt_inputs], h[:outputs])
+      end
+      docs.join("\n")
+    end
+
+    def generate_function_documentation(func_info, inputs, opt_inputs, outputs)
+      [
+        generate_function_description(func_info, inputs, opt_inputs),
+        generate_input_documentation(inputs),
+        generate_optional_input_documentation(opt_inputs),
+        generate_output_documentation(outputs),
+        generate_error_documentation
+      ].flatten.compact.join("\n")
+    end
+
+    def generate_function_description(func_info, inputs, opt_inputs) # rubocop:disable Metrics/MethodLength,Metrics/AbcSize
+      args = []
+      inputs.map do |input|
+        args << TALibFFI.normalize_parameter_name(input["paramName"].to_s)
+      end
+
+      opt_inputs.map do |opt_input|
+        param_name = TALibFFI.normalize_parameter_name(opt_input["paramName"].to_s)
+        args << "#{param_name}: #{opt_input["defaultValue"]}"
+      end
+
+      [
+        "    # @!method #{func_info["name"].to_s.downcase}(#{args.join(", ")})",
+        "    # #{func_info["hint"].to_s.strip}",
+        "    #"
+      ]
+    end
+
+    def generate_input_documentation(inputs)
+      inputs.map do |input|
+        param_name = TALibFFI.normalize_parameter_name(input["paramName"].to_s)
+        flags = TALibFFI.extract_flags(input["flags"], :TA_InputFlags)
+        description = flags.empty? ? "Input values" : flags.join(", ")
+        "    # @param #{param_name} [Array<Float>]  #{description}"
+      end
+    end
+
+    def generate_optional_input_documentation(opt_inputs)
+      opt_inputs.map do |opt_input|
+        param_name = TALibFFI.normalize_parameter_name(opt_input["paramName"].to_s)
+        type = opt_input["type"] == TALibFFI::TA_PARAM_TYPE[:TA_OptInput_RealRange] ? "Float" : "Integer"
+        "    # @param #{param_name} [#{type}]  #{opt_input["hint"]} (default: #{opt_input["defaultValue"]})"
+      end
+    end
+
+    def generate_output_documentation(outputs) # rubocop:disable Metrics/MethodLength
+      if outputs.length == 1
+        type = outputs.first["type"] == TALibFFI::TA_PARAM_TYPE[:TA_Output_Real] ? "Float" : "Integer"
+        ["    # @return [Array<#{type}>]"]
+      else
+        [
+          "    # @return [Hash]  Hash containing the following arrays:",
+          *outputs.map do |output|
+            param_name = TALibFFI.normalize_parameter_name(output["paramName"].to_s)
+            type = output["type"] == TALibFFI::TA_PARAM_TYPE[:TA_Output_Real] ? "Float" : "Integer"
+            "    # @option result [Array<#{type}>] :#{param_name}  Output values"
+          end
+        ]
+      end
+    end
+
+    def generate_error_documentation
+      "    # @raise [TALibError]  If there is an error in function execution\n"
+    end
+  end
+end

--- a/ta_lib_ffi.gemspec
+++ b/ta_lib_ffi.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.description = "A Ruby wrapper for TA-Lib using FFI, providing technical analysis functions for financial market data"
   spec.homepage = "https://github.com/TA-Lib/ta-lib-ruby"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.0.0"
+  spec.required_ruby_version = ">= 3.1.0"
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/TA-Lib/ta-lib-ruby"
@@ -34,6 +34,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.13"
   spec.add_development_dependency "rubocop-rspec", "~> 3.3"
   spec.add_development_dependency "ruby-lsp-rspec", "~> 0.1.20"
+  spec.add_development_dependency "webrick", "~> 1.9"
+  spec.add_development_dependency "yard", "~> 0.9"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html


### PR DESCRIPTION
- Add YARD documentation generator for TA-Lib functions
- Implement dynamic documentation insertion into ta_lib_ffi.rb
- Add YARD rake task with exclude options
- Add documentation for all module methods
- Fix parameter type documentation for array and symbol inputs
- Update Ruby version requirement to >= 3.1.0

The documentation generator dynamically creates YARD-style documentation
for all TA-Lib functions and inserts it between markers in the main module file.